### PR TITLE
Update e2b code interpreter

### DIFF
--- a/client/astra_assistants/tools/e2b_code_interpreter.py
+++ b/client/astra_assistants/tools/e2b_code_interpreter.py
@@ -1,4 +1,5 @@
 from e2b_code_interpreter import Sandbox
+
 from astra_assistants.tools.tool_interface import ToolInterface
 
 

--- a/client/astra_assistants/tools/e2b_code_interpreter.py
+++ b/client/astra_assistants/tools/e2b_code_interpreter.py
@@ -1,7 +1,4 @@
-from e2b import Sandbox
-
-from e2b_code_interpreter import CodeInterpreter
-
+from e2b_code_interpreter import Sandbox
 from astra_assistants.tools.tool_interface import ToolInterface
 
 
@@ -18,7 +15,7 @@ class E2BCodeInterpreter(ToolInterface):
         else:
             # Sandbox not found
             pass
-        self.code_interpreter = CodeInterpreter()
+        self.code_interpreter = Sandbox()
 
         print("initialized")
 


### PR DESCRIPTION

**Title:** Update `E2BCodeInterpreter` to Use `Sandbox` from `e2b_code_interpreter`

**Description:**

Hi guys.

I've updated the `E2BCodeInterpreter` class in `astra_assistants/tools` to improve compatibility with `e2b_code_interpreter` by removing the `CodeInterpreter` dependency, as it is not included in `e2b_code_interpreter`. The changes streamline sandbox handling by directly using `Sandbox`, as shown below:

**Original Code:**
```python
from e2b import Sandbox
from e2b_code_interpreter import CodeInterpreter
from astra_assistants.tools.tool_interface import ToolInterface

class E2BCodeInterpreter(ToolInterface):
    def __init__(self):
        print("initializing code interpreter")
        running_sandboxes = Sandbox.list()
        # Find the sandbox by metadata
        for running_sandbox in running_sandboxes:
            sandbox = Sandbox.reconnect(running_sandbox.sandbox_id)
            sandbox.close()
        else:
            # Sandbox not found
            pass
        self.code_interpreter = CodeInterpreter()
        print("initialized")

    def call(self, arguments):
        code = arguments['arguments']
        exec = self.code_interpreter.notebook.exec_cell(code)
        return exec.text
```

**Updated Code:**
```python
from e2b_code_interpreter import Sandbox
from astra_assistants.tools.tool_interface import ToolInterface

class E2BCodeInterpreter(ToolInterface):
    def __init__(self):
        print("initializing code interpreter")
        running_sandboxes = Sandbox.list()
        # Find the sandbox by metadata
        for running_sandbox in running_sandboxes:
            sandbox = Sandbox.reconnect(running_sandbox.sandbox_id)
            sandbox.close()
        else:
            pass
        self.code_interpreter = Sandbox()
        print("initialized")

    def call(self, arguments):
        code = arguments['arguments']
        exec = self.code_interpreter.notebook.exec_cell(code)
        return exec.text
```

This change came about because I was having problems using langflow locally. Much details here : 
https://github.com/langflow-ai/langflow/issues/4295
